### PR TITLE
Invalid hostnames in acf print error but keep going.

### DIFF
--- a/src/p4p/asLib/__init__.py
+++ b/src/p4p/asLib/__init__.py
@@ -184,8 +184,13 @@ class Engine(object):
         hag_addr = defaultdict(set)
 
         for host, groups in _hag.items():
-            ip = self._gethostbyname(host)
-            hag_addr[ip] |= groups
+            try:
+                ip = self._gethostbyname(host)
+                hag_addr[ip] |= groups
+            except socket.gaierror as e:
+                print( "Invalid hostname %s" % host )
+                print( "%s: %s" % ( type(e).__name__, str(e) ) )
+                pass
 
         return dict(hag_addr)
 


### PR DESCRIPTION
Prior code would throw socket.gaierror if a hostname in the access file is invalid.
This is a problem in production environments as control room hosts come and go
and gateway shouldn't fail to launch due to invalid hostnames in HAG lists.