### PR TITLE
add type hints to Handler

### DIFF
--- a/src/p4p/server/raw.py
+++ b/src/p4p/server/raw.py
@@ -1,8 +1,12 @@
 
+import typing
 import logging
 _log = logging.getLogger(__name__)
 
 from .._p4p import SharedPV as _SharedPV
+
+if typing.TYPE_CHECKING:
+    from .._p4p import ServerOperation
 
 __all__ = (
     'SharedPV',
@@ -40,7 +44,7 @@ class Handler(object):
     Use of this as a base class is optional.
     """
 
-    def put(self, pv, op):
+    def put(self, pv: _SharedPV, op: ServerOperation):
         """
         Called each time a client issues a Put
         operation on this Channel.
@@ -50,7 +54,7 @@ class Handler(object):
         """
         op.done(error='Not supported')
 
-    def rpc(self, pv, op):
+    def rpc(self, pv: _SharedPV, op: ServerOperation):
         """
         Called each time a client issues a Remote Procedure Call
         operation on this Channel.
@@ -60,7 +64,7 @@ class Handler(object):
         """
         op.done(error='Not supported')
 
-    def onFirstConnect(self, pv):
+    def onFirstConnect(self, pv: _SharedPV):
         """
         Called when the first Client channel is created.
 
@@ -68,7 +72,7 @@ class Handler(object):
         """
         pass
 
-    def onLastDisconnect(self, pv):
+    def onLastDisconnect(self, pv: _SharedPV):
         """
         Called when the last Client channel is closed.
 


### PR DESCRIPTION
Sorry - this looks a bit weird, but as type hinting isn't in 2.7 and `master` supports 2.7 i guess this is the right place to point this PR(?) - type checking was added in 3.5 

This is a very simple change which adds type hinting to the `Handler` class so that downstream users of ie. the `put()` decorator can also type hint their decorated functions/calls to put etc. directly. 
